### PR TITLE
Conflicting relays edit

### DIFF
--- a/CoopDoorOpener-beta.py
+++ b/CoopDoorOpener-beta.py
@@ -38,13 +38,17 @@ def set_Open_Relay_On():
     GPIO.setmode(GPIO.BCM)
 
     # init pin numbers
-    pin_num = [6]
+    pin_Open = [6]
+    pin_Close = [22]
 
     # set mode default state is 'low'
-    GPIO.setup(pin_num, GPIO.OUT) 
+    GPIO.setup(pin_Open, GPIO.OUT) 
+    GPIO.setup(pin_Close, GPIO.OUT)
    
-    # Activate Relay to High (High turns Relay on)
-    GPIO.output(pin_num, GPIO.HIGH)
+    # Activate Close Relay to Low and Open Relay to High (High turns Relay on)
+    GPIO.output(pin_Close, GPIO.LOW)     # Turn off Close Relay
+    time.sleep(2)                        # This insures close relay is off before turning on Open relay
+    GPIO.output(pin_Open, GPIO.HIGH)      # Activate Open relay
     
     # Start Timer for duration actuator will be activated
     timer = 0
@@ -53,7 +57,7 @@ def set_Open_Relay_On():
         time.sleep(1)
 
     # set Open relay back to low (Turns Relay off)
-    GPIO.output(pin_num, GPIO.LOW)
+    GPIO.output(pin_Open, GPIO.LOW)
 
     # Reset GPIO settings
     GPIO.cleanup()
@@ -69,13 +73,17 @@ def set_Close_Relay_On():
     GPIO.setmode(GPIO.BCM)
 
     # # init pin numbers
-    pin_num = [22]
+    pin_Open = [6]
+    pin_Close = [22]
 
     # # set mode default state is 'low'
-    GPIO.setup(pin_num, GPIO.OUT) 
+    GPIO.setup(pin_Open, GPIO.OUT) 
+    GPIO.setup(pin_Close, GPIO.OUT)
    
     # # Activate Relay to High
-    GPIO.output(pin_num, GPIO.HIGH)
+    GPIO.output(pin_Open, GPIO.LOW)        # Turn off Open Relay
+    time.sleep(2)                          # This insures Open relay is off before turning on Close relay
+    GPIO.output(pin_Close, GPIO.HIGH)      # Activate Close relay
 
     # Start Timer for duration actuator will be activated
     timer = 0

--- a/CoopDoorOpener-beta.py
+++ b/CoopDoorOpener-beta.py
@@ -47,8 +47,8 @@ def set_Open_Relay_On():
    
     # Activate Close Relay to Low and Open Relay to High (High turns Relay on)
     GPIO.output(pin_Close, GPIO.LOW)     # Turn off Close Relay
-    time.sleep(2)                        # This insures close relay is off before turning on Open relay
-    GPIO.output(pin_Open, GPIO.HIGH)      # Activate Open relay
+    time.sleep(2)                        # This insures Close relay is off before turning on Open relay
+    GPIO.output(pin_Open, GPIO.HIGH)     # Activate Open relay
     
     # Start Timer for duration actuator will be activated
     timer = 0

--- a/CoopDoorOpener-beta.py
+++ b/CoopDoorOpener-beta.py
@@ -12,6 +12,10 @@ door_Status_Var = ""
 def open_Coop():
     global door_Status_Var
 
+    # Set buttons to DISABLE till operation ends
+    open_Button['state'] = DISABLED
+    close_Button['state'] = DISABLED
+
     # Set Label variables to current status of Coop Door
     door_Status_Var.set("Opening Coop Door")
     label_Door_Status['fg'] = "red"
@@ -22,6 +26,10 @@ def open_Coop():
 
 def close_Coop():
     global door_Status_Var
+
+    # Set buttons to DISABLE till operation ends
+    open_Button['state'] = DISABLED
+    close_Button['state'] = DISABLED
 
     # Set Label variables to current status of Coop Door
     door_Status_Var.set("Closing Coop Door")
@@ -63,6 +71,10 @@ def set_Open_Relay_On():
     label_Door_Status['fg'] = "green"
     statusbar['text'] = "Coop Status = Open"
 
+    # Turn Button Status back to NORMAL Operation
+    open_Button['state'] = NORMAL
+    close_Button['state'] = NORMAL
+
 def set_Close_Relay_On():
     global door_Status_Var
     # 
@@ -94,6 +106,10 @@ def set_Close_Relay_On():
     label_Door_Status['fg'] = "green"
     statusbar['text'] = "Coop Status = Closed"
 
+    # Turn Button Status back to NORMAL Operation
+    open_Button['state'] = NORMAL
+    close_Button['state'] = NORMAL
+
 # Main Window
 window = Tk()
 window.title("Automatic Chicken Coop Door")
@@ -116,18 +132,18 @@ header_Label = Label (top_Frame, text="Choose Open or Close Coop", font="none 12
 header_Label.pack(pady=15)
 
 #create Open and Close Buttons
-openButton = Button(middle_Frame, text="Open Coop", width=10, command=open_Coop) 
-openButton.pack(side=LEFT, padx=15)
-closeButton = Button(middle_Frame, text="Close Coop", width=10, command=close_Coop) 
-closeButton.pack(side=LEFT, padx=15)
+open_Button = Button(middle_Frame, text="Open Coop", width=10, command=open_Coop) 
+open_Button.pack(side=LEFT, padx=15)
+close_Button = Button(middle_Frame, text="Close Coop", width=10, command=close_Coop) 
+close_Button.pack(side=LEFT, padx=15)
 
 # Door Status Label
 label_Door_Status = Label (window, textvariable=door_Status_Var, font="none 14 bold", fg="red")
 label_Door_Status.pack()
 
 #create status bar
-statusbar = Label(window, text="Coop Status (unknown)", relief=SUNKEN, anchor=W)
-statusbar.pack(side=BOTTOM, fill=X)
+statu_Bar = Label(window, text="Coop Status (unknown)", relief=SUNKEN, anchor=W)
+status_Bar.pack(side=BOTTOM, fill=X)
 
 # Run main loop
 window.mainloop()

--- a/CoopDoorOpener-beta.py
+++ b/CoopDoorOpener-beta.py
@@ -17,8 +17,8 @@ def open_Coop():
     label_Door_Status['fg'] = "red"
 
     # Start set_Open_Relay_On in new thread to avoid window lockup
-    t1 = threading.Thread(target=set_Open_Relay_On)
-    t1.start()
+    t_Open = threading.Thread(target=set_Open_Relay_On)
+    t_Open.start()
 
 def close_Coop():
     global door_Status_Var
@@ -28,8 +28,8 @@ def close_Coop():
     label_Door_Status['fg'] = "red"
 
     # Start set_Close_Relay_On in new thread to avoid window lockup
-    t1 = threading.Thread(target=set_Close_Relay_On)
-    t1.start()
+    t_Close = threading.Thread(target=set_Close_Relay_On)
+    t_Close.start()
 
 def set_Open_Relay_On():
     global door_Status_Var

--- a/CoopDoorOpener-beta.py
+++ b/CoopDoorOpener-beta.py
@@ -92,7 +92,7 @@ def set_Close_Relay_On():
         time.sleep(1)
 
     # set Close relay back to low (off)
-    GPIO.output(pin_num, GPIO.LOW)
+    GPIO.output(pin_Close, GPIO.LOW)
 
     # Reset GPIO settings
     GPIO.cleanup()

--- a/CoopDoorOpener-beta.py
+++ b/CoopDoorOpener-beta.py
@@ -1,6 +1,6 @@
 # Automatic Chicken Coop Door Opener Beta 0.1
 
-# Import Tkinter Libraries
+# Import Libraries
 from tkinter import *
 import RPi.GPIO as GPIO
 import time

--- a/CoopDoorOpener-beta.py
+++ b/CoopDoorOpener-beta.py
@@ -39,15 +39,11 @@ def set_Open_Relay_On():
 
     # init pin numbers
     pin_Open = [6]
-    pin_Close = [22]
 
     # set mode default state is 'low'
     GPIO.setup(pin_Open, GPIO.OUT) 
-    GPIO.setup(pin_Close, GPIO.OUT)
    
-    # Activate Close Relay to Low and Open Relay to High (High turns Relay on)
-    GPIO.output(pin_Close, GPIO.LOW)     # Turn off Close Relay
-    time.sleep(2)                        # This insures Close relay is off before turning on Open relay
+    # Activate Open Relay to High (High turns Relay on)
     GPIO.output(pin_Open, GPIO.HIGH)     # Activate Open relay
     
     # Start Timer for duration actuator will be activated
@@ -73,16 +69,12 @@ def set_Close_Relay_On():
     GPIO.setmode(GPIO.BCM)
 
     # # init pin numbers
-    pin_Open = [6]
     pin_Close = [22]
 
     # # set mode default state is 'low'
-    GPIO.setup(pin_Open, GPIO.OUT) 
     GPIO.setup(pin_Close, GPIO.OUT)
    
-    # # Activate Relay to High
-    GPIO.output(pin_Open, GPIO.LOW)        # Turn off Open Relay
-    time.sleep(2)                          # This insures Open relay is off before turning on Close relay
+    # # Activate Close Relay to High
     GPIO.output(pin_Close, GPIO.HIGH)      # Activate Close relay
 
     # Start Timer for duration actuator will be activated

--- a/CoopDoorOpener-beta.py
+++ b/CoopDoorOpener-beta.py
@@ -69,7 +69,7 @@ def set_Open_Relay_On():
     # Set Label Variables defining current state of Coop Door
     door_Status_Var.set("Coop Door is Open")
     label_Door_Status['fg'] = "green"
-    statusbar['text'] = "Coop Status = Open"
+    status_Bar['text'] = "Coop Status = Open"
 
     # Turn Button Status back to NORMAL Operation
     open_Button['state'] = NORMAL
@@ -104,7 +104,7 @@ def set_Close_Relay_On():
     # Set Label variables defining the current state of Coop Door
     door_Status_Var.set("Coop Door is Closed")
     label_Door_Status['fg'] = "green"
-    statusbar['text'] = "Coop Status = Closed"
+    status_Bar['text'] = "Coop Status = Closed"
 
     # Turn Button Status back to NORMAL Operation
     open_Button['state'] = NORMAL
@@ -142,7 +142,7 @@ label_Door_Status = Label (window, textvariable=door_Status_Var, font="none 14 b
 label_Door_Status.pack()
 
 #create status bar
-statu_Bar = Label(window, text="Coop Status (unknown)", relief=SUNKEN, anchor=W)
+status_Bar = Label(window, text="Coop Status (unknown)", relief=SUNKEN, anchor=W)
 status_Bar.pack(side=BOTTOM, fill=X)
 
 # Run main loop


### PR DESCRIPTION
Problem:
While one thread was running, the user could push on either "Open" or "Close" button and start another thread.  The issue, other than the possibility of having multiple threads started by an overzealous user, was that the Open and Close thread would be running at the same time providing power to both relays at once burning out the actuator.

Original Solution:
My original solution, was to simply shut down one relay before starting the other.  The problem with that solution was the other thread was still running and when finished would shut off the relay and provide output while the other thread was still running.  This proposed two issues, not only could the user still press a button multiple times (or both buttons multiple times) confusing what state the door was actually in physically, but didn't stop them from running unknown number of threads.

Final Solution:
Disable the buttons while the thread is running and re enable them when the thread is done.